### PR TITLE
Simple safety check

### DIFF
--- a/contracts/mocks/DummyImplementation.sol
+++ b/contracts/mocks/DummyImplementation.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.4.21;
+
+contract DummyImplementation {
+
+}

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.21;
 
 import './Proxy.sol';
+import 'zeppelin-solidity/contracts/AddressUtils.sol';
 
 /**
  * @title UpgradeabilityProxy
@@ -48,7 +49,7 @@ contract UpgradeabilityProxy is Proxy {
    * @param newImplementation representing the address of the new implementation to be set
    */
   function _upgradeTo(address newImplementation) internal {
-    require(newImplementation != address(0));
+    require(AddressUtils.isContract(newImplementation));
     address currentImplementation = implementation();
     require(currentImplementation != newImplementation);
     setImplementation(newImplementation);

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -38,10 +38,14 @@ contract UpgradeabilityProxy is Proxy {
    * @param newImplementation address representing the new implementation to be set
    */
   function setImplementation(address newImplementation) internal {
+    require(AddressUtils.isContract(newImplementation));
+
     bytes32 position = implementationPosition;
     assembly {
       sstore(position, newImplementation)
     }
+
+    emit Upgraded(newImplementation);
   }
 
   /**
@@ -49,10 +53,8 @@ contract UpgradeabilityProxy is Proxy {
    * @param newImplementation representing the address of the new implementation to be set
    */
   function _upgradeTo(address newImplementation) internal {
-    require(AddressUtils.isContract(newImplementation));
     address currentImplementation = implementation();
     require(currentImplementation != newImplementation);
     setImplementation(newImplementation);
-    emit Upgraded(newImplementation);
   }
 }

--- a/test/application/management/AppDirectory.test.js
+++ b/test/application/management/AppDirectory.test.js
@@ -2,14 +2,20 @@ const AppDirectory = artifacts.require('AppDirectory')
 const assertRevert = require('../../helpers/assertRevert')
 const ContractDirectory = artifacts.require('ContractDirectory')
 const shouldBehaveLikeContractDirectory = require('../versioning/ContractDirectory.behavior')
+const DummyImplementation = artifacts.require('DummyImplementation')
 
-contract('AppDirectory', ([_, owner, stdlibOwner, anotherAddress, implementation_v0, implementation_v1, stdlibImplementation]) => {
+contract('AppDirectory', ([_, owner, stdlibOwner, anotherAddress, stdlibImplementation]) => {
+  before(async function () {
+    this.implementation_v0 = (await DummyImplementation.new()).address
+    this.implementation_v1 = (await DummyImplementation.new()).address
+  })
+
   beforeEach(async function () {
     this.directory = await AppDirectory.new(0x0, { from: owner })
     this.stdlib = await ContractDirectory.new({ from: stdlibOwner })
   })
 
-  shouldBehaveLikeContractDirectory(owner, anotherAddress, implementation_v0, implementation_v1)
+  shouldBehaveLikeContractDirectory(owner, anotherAddress)
 
   describe('getImplementation', function () {
     const contractName = 'ERC721'
@@ -17,12 +23,12 @@ contract('AppDirectory', ([_, owner, stdlibOwner, anotherAddress, implementation
     describe('when no stdlib was set', function () {
       describe('when the requested contract was registered in the directory', function () {
         beforeEach(async function () {
-          await this.directory.setImplementation(contractName, implementation_v0, { from: owner })
+          await this.directory.setImplementation(contractName, this.implementation_v0, { from: owner })
         })
 
         it('returns the directory implementation', async function () {
           const implementation = await this.directory.getImplementation(contractName)
-          assert.equal(implementation, implementation_v0)
+          assert.equal(implementation, this.implementation_v0)
         })
       })
 
@@ -41,7 +47,7 @@ contract('AppDirectory', ([_, owner, stdlibOwner, anotherAddress, implementation
 
       describe('when the requested contract was registered in the directory', function () {
         beforeEach(async function () {
-          await this.directory.setImplementation(contractName, implementation_v0, { from: owner })
+          await this.directory.setImplementation(contractName, this.implementation_v0, { from: owner })
         })
 
         describe('when the requested contract was registered in the stdlib', function () {
@@ -51,14 +57,14 @@ contract('AppDirectory', ([_, owner, stdlibOwner, anotherAddress, implementation
 
           it('returns the directory implementation', async function () {
             const implementation = await this.directory.getImplementation(contractName)
-            assert.equal(implementation, implementation_v0)
+            assert.equal(implementation, this.implementation_v0)
           })
         })
 
         describe('when the requested contract was not registered in the stdlib', function () {
           it('returns the directory implementation', async function () {
             const implementation = await this.directory.getImplementation(contractName)
-            assert.equal(implementation, implementation_v0)
+            assert.equal(implementation, this.implementation_v0)
           })
         })
       })

--- a/test/application/versioning/ContractDirectory.behavior.js
+++ b/test/application/versioning/ContractDirectory.behavior.js
@@ -2,7 +2,7 @@ const assertRevert = require('../../helpers/assertRevert')
 const ContractDirectory = artifacts.require('ContractDirectory')
 const shouldBehaveLikeOwnable = require('../../ownership/Ownable.behavior')
 
-function shouldBehaveLikeContractDirectory(owner, anotherAddress, implementation_v0, implementation_v1) {
+function shouldBehaveLikeContractDirectory(owner, anotherAddress) {
   describe('ownership', function () {
     beforeEach(function () {
       this.ownable = this.directory
@@ -19,39 +19,39 @@ function shouldBehaveLikeContractDirectory(owner, anotherAddress, implementation
       const from = owner
 
       it('registers the given contract', async function () {
-        await this.directory.setImplementation(contractName, implementation_v0, { from })
+        await this.directory.setImplementation(contractName, this.implementation_v0, { from })
 
         const registeredImplementation = await this.directory.getImplementation(contractName)
-        assert.equal(registeredImplementation, implementation_v0)
+        assert.equal(registeredImplementation, this.implementation_v0)
       })
 
       it('emits an event', async function () {
-        const { logs } = await this.directory.setImplementation(contractName, implementation_v0, { from })
+        const { logs } = await this.directory.setImplementation(contractName, this.implementation_v0, { from })
 
         assert.equal(logs.length, 1)
         assert.equal(logs[0].event, 'ImplementationAdded')
         assert.equal(logs[0].args.contractName, contractName)
-        assert.equal(logs[0].args.implementation, implementation_v0)
+        assert.equal(logs[0].args.implementation, this.implementation_v0)
       })
 
       it('allows to register a another implementation of the same contract', async function () {
-        await this.directory.setImplementation(contractName, implementation_v0, { from })
-        await this.directory.setImplementation(contractName, implementation_v1, { from })
+        await this.directory.setImplementation(contractName, this.implementation_v0, { from })
+        await this.directory.setImplementation(contractName, this.implementation_v1, { from })
 
         const registeredImplementation = await this.directory.getImplementation(contractName)
-        assert.equal(registeredImplementation, implementation_v1)
+        assert.equal(registeredImplementation, this.implementation_v1)
       })
 
       it('allows to register another contract', async function () {
         const anotherContract = 'anotherContract';
-        await this.directory.setImplementation(anotherContract, implementation_v1, { from })
+        await this.directory.setImplementation(anotherContract, this.implementation_v1, { from })
 
         const registeredImplementation = await this.directory.getImplementation(anotherContract)
-        assert.equal(registeredImplementation, implementation_v1)
+        assert.equal(registeredImplementation, this.implementation_v1)
       })
 
       it('allows to unregister a contract', async function () {
-        await this.directory.setImplementation(contractName, implementation_v0, { from })
+        await this.directory.setImplementation(contractName, this.implementation_v0, { from })
         await this.directory.setImplementation(contractName, ZERO_ADDRESS, { from })
 
         const registeredImplementation = await this.directory.getImplementation(contractName)
@@ -63,7 +63,7 @@ function shouldBehaveLikeContractDirectory(owner, anotherAddress, implementation
       const from = anotherAddress
 
       it('reverts', async function () {
-        await assertRevert(this.directory.setImplementation(contractName, implementation_v0, { from }))
+        await assertRevert(this.directory.setImplementation(contractName, this.implementation_v0, { from }))
       })
     })
   })

--- a/test/application/versioning/ContractDirectory.test.js
+++ b/test/application/versioning/ContractDirectory.test.js
@@ -1,10 +1,16 @@
 const ContractDirectory = artifacts.require('ContractDirectory')
 const shouldBehaveLikeContractDirectory = require('./ContractDirectory.behavior')
+const DummyImplementation = artifacts.require('DummyImplementation')
 
-contract('ContractDirectory', ([_, owner, anotherAddress, implementation_v0, implementation_v1]) => {
+contract('ContractDirectory', ([_, owner, anotherAddress]) => {
+  before(async function () {
+    this.implementation_v0 = (await DummyImplementation.new()).address
+    this.implementation_v1 = (await DummyImplementation.new()).address
+  })
+
   beforeEach(async function () {
     this.directory = await ContractDirectory.new({ from: owner })
   })
 
-  shouldBehaveLikeContractDirectory(owner, anotherAddress, implementation_v0, implementation_v1)
+  shouldBehaveLikeContractDirectory(owner, anotherAddress, this.implementation_v0, this.implementation_v1)
 })

--- a/test/application/versioning/FreezableContractDirectory.test.js
+++ b/test/application/versioning/FreezableContractDirectory.test.js
@@ -1,8 +1,14 @@
 const assertRevert = require('../../helpers/assertRevert')
 const FreezableContractDirectory = artifacts.require('FreezableContractDirectory')
 const shouldBehaveLikeContractDirectory = require('./ContractDirectory.behavior')
+const DummyImplementation = artifacts.require('DummyImplementation')
 
-contract('FreezableContractDirectory', ([_, owner, anotherAddress, implementation_v0, implementation_v1]) => {
+contract('FreezableContractDirectory', ([_, owner, anotherAddress]) => {
+  before(async function () {
+    this.implementation_v0 = (await DummyImplementation.new()).address
+    this.implementation_v1 = (await DummyImplementation.new()).address
+  })
+
   beforeEach(async function () {
     this.directory = await FreezableContractDirectory.new({ from: owner })
   })
@@ -46,7 +52,7 @@ contract('FreezableContractDirectory', ([_, owner, anotherAddress, implementatio
 
   describe('setImplementation', function () {
     describe('when it is not frozen', function () {
-      shouldBehaveLikeContractDirectory(owner, anotherAddress, implementation_v0, implementation_v1)
+      shouldBehaveLikeContractDirectory(owner, anotherAddress, this.implementation_v0, this.implementation_v1)
     })
 
     describe('when it is frozen', function () {
@@ -55,7 +61,7 @@ contract('FreezableContractDirectory', ([_, owner, anotherAddress, implementatio
       })
 
       it('reverts', async function () {
-        await assertRevert(this.directory.setImplementation('ERC721', implementation_v1, { from: owner }))
+        await assertRevert(this.directory.setImplementation('ERC721', this.implementation_v1, { from: owner }))
       })
     })
   })

--- a/test/application/versioning/Package.test.js
+++ b/test/application/versioning/Package.test.js
@@ -2,8 +2,14 @@ const Package = artifacts.require('Package')
 const assertRevert = require('../../helpers/assertRevert')
 const ContractDirectory = artifacts.require('ContractDirectory')
 const shouldBehaveLikeOwnable = require('../../ownership/Ownable.behavior')
+const DummyImplementation = artifacts.require('DummyImplementation')
 
-contract('Package', ([_, owner, anotherAddress, implementation_v0]) => {
+contract('Package', ([_, owner, anotherAddress]) => {
+  before(async function () {
+    this.implementation_v0 = (await DummyImplementation.new()).address
+    this.implementation_v1 = (await DummyImplementation.new()).address
+  })
+
   beforeEach(async function () {
     this.package = await Package.new({ from: owner })
     this.directory_V0 = await ContractDirectory.new({ from: owner })
@@ -132,12 +138,12 @@ contract('Package', ([_, owner, anotherAddress, implementation_v0]) => {
 
       describe('when the requested version holds the requested contract name', function () {
         beforeEach(async function () {
-          await this.directory_V0.setImplementation(contractName, implementation_v0, { from: owner })
+          await this.directory_V0.setImplementation(contractName, this.implementation_v0, { from: owner })
         })
 
         it('returns the requested implementation', async function () {
           const implementation = await this.package.getImplementation(version, contractName)
-          assert.equal(implementation, implementation_v0)
+          assert.equal(implementation, this.implementation_v0)
         })
       })
 

--- a/test/upgradeability/UpgradeabilityProxyFactory.test.js
+++ b/test/upgradeability/UpgradeabilityProxyFactory.test.js
@@ -4,15 +4,20 @@ const encodeCall = require('../helpers/encodeCall')
 const InitializableMock = artifacts.require('InitializableMock')
 const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy')
 const UpgradeabilityProxyFactory = artifacts.require('UpgradeabilityProxyFactory')
+const DummyImplementation = artifacts.require('DummyImplementation')
 
-contract('UpgradeabilityProxyFactory', ([_, owner, implementation_v0]) => {
+contract('UpgradeabilityProxyFactory', ([_, owner]) => {
+  before(async function () {
+    this.implementation_v0 = (await DummyImplementation.new()).address
+  })
+
   beforeEach(async function () {
     this.factory = await UpgradeabilityProxyFactory.new()
   })
 
   describe('createProxy', function () {
     beforeEach(async function () {
-      const { logs } = await this.factory.createProxy(owner, implementation_v0)
+      const { logs } = await this.factory.createProxy(owner, this.implementation_v0)
       this.logs = logs
       this.proxyAddress = this.logs.find(l => l.event === 'ProxyCreated').args.proxy
       this.proxy = await OwnedUpgradeabilityProxy.at(this.proxyAddress)
@@ -20,7 +25,7 @@ contract('UpgradeabilityProxyFactory', ([_, owner, implementation_v0]) => {
 
     it('creates a proxy pointing to the requested implementation', async function () {
       const implementation = await this.proxy.implementation()
-      assert.equal(implementation, implementation_v0)
+      assert.equal(implementation, this.implementation_v0)
     })
 
     it('transfers the ownership to the requested owner', async function () {


### PR DESCRIPTION
See #28.

Currently `UpgradeabilityProxy`s can have an implementation that is an account and not a contract. This PR requires the implementation to be a contract. The change was rather simple but most of the tests had to be modified because they were using accounts as the implementations. I think the tests are better this way.